### PR TITLE
Refactor versión 2X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@
 - CI con cache de pip, pre-commit, pytest y cobertura.
 - Nuevas pruebas de reconexión y checkpoint.
 
+## v2X
+
+- Refactor de `server.py` con parseo desacoplado y reconexión robusta.
+- Nueva función `wal_checkpoint` y limpieza segura de BD.
+- Tests ampliados y flujo de integración completo.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sensor App
+# Sensor App v2X
 
 ![CI](https://github.com/tu_usuario/sensor_app/actions/workflows/ci.yml/badge.svg)
 ![Coverage](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)
@@ -98,6 +98,9 @@ De este modo los chequeos se ejecutarán automáticamente antes de cada commit.
 * **Retención**:
 
   * La línea `DELETE FROM lecturas WHERE Tiempo < datetime('now','-7 days')` mantiene sólo 7 días de datos. Modifícala si necesitas otro periodo.
+* **Rutas y VID/PID**:
+  * Las carpetas `data/` y `logs/` se crean con permisos 700 y pueden cambiarse con las constantes `DATA_DIR` y `LOG_DIR` en `server.py`.
+  * Los identificadores USB del Arduino (`ARDUINO_VID`, `ARDUINO_PID`) también son configurables al inicio del script.
 
 ## Contribuciones
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 os.environ.setdefault("TELEGRAM_TOKEN", "x")
 os.environ.setdefault("TELEGRAM_CHAT_ID", "x")
 
-from server import conectar_db, flush_db, safe_execute  # noqa: E402
+from server import conectar_db, flush_db, safe_execute, wal_checkpoint  # noqa: E402
 
 
 def test_safe_execute_error(tmp_path):
@@ -33,6 +33,7 @@ def test_flush_db(tmp_path):
     ]
 
     inserted = flush_db(conn, buffer)
+    wal_checkpoint(conn)
     assert inserted == 1
     cur = conn.execute("SELECT COUNT(*) FROM lecturas")
     assert cur.fetchone()[0] == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,3 +31,8 @@ def test_parse_sensor_block_valid():
 def test_parse_sensor_block_invalid():
     lines = ["foo", "bar"]
     assert parse_sensor_block(lines) == {}
+
+
+def test_parse_sensor_block_unknown_label():
+    lines = ["Desconocido: 123"]
+    assert parse_sensor_block(lines) == {}


### PR DESCRIPTION
## Summary
- refactor server initialization and serial reconnection
- separate WAL checkpoint and add function `wal_checkpoint`
- extend parser with unknown label handling
- add integration and unit tests
- document configurable constants
- update changelog for v2X

## Testing
- `pre-commit run --files server.py tests/test_parser.py tests/test_db.py tests/test_integration.py Dockerfile README.md CHANGELOG.md .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4fbaf2588328ab4ec9e3a0e226ad